### PR TITLE
overflowing_literals false positive

### DIFF
--- a/src/os/linux.rs
+++ b/src/os/linux.rs
@@ -181,4 +181,4 @@ pub const TCSAFLUSH: c_int = 2;
 
 // ioctls should be a c_uint, not a c_int. the warning cause by this should
 // be ignore until the bug in ioctl-rs is fixed.
-pub const TCGETS2: c_int = (0x802c_542a as c_int);
+pub const TCGETS2: c_int = (0x802c_542a_u32 as c_int);


### PR DESCRIPTION
In a future version of Rust the `overflowing_literals` lint will become deny by default. See rust-lang/rust#55632. When checking for breakage in crates uploaded to crates.io it was discovered that this crate will no longer compile thanks to this lint. The error produced is [here](https://crater-reports.s3.amazonaws.com/pr-55632/try%23dc13be39fae8d4c607889b27de374b52586485a3/reg/dmx-termios-0.3.0/log.txt). This PR should fix the false positive.